### PR TITLE
Migration from Cglib to ByteBuddy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 *.iml
 target/
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.1.1</version>
+            <version>6.9.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>ru.custis.beanpath</groupId>
     <artifactId>beanpath</artifactId>
-    <version>1.0.1</version>
+    <version>1.1</version>
     <packaging>jar</packaging>
 
     <name>CUSTIS beanpath</name>
@@ -54,8 +54,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>com.google.guava:*</include>
-                                    <include>cglib:*</include>
-                                    <include>org.ow2.asm:*</include>
+                                    <include>net.bytebuddy:*</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
@@ -64,12 +63,8 @@
                                     <shadedPattern>ru.custis.beanpath.shaded.com.google</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>net.sf.cglib</pattern>
-                                    <shadedPattern>ru.custis.beanpath.shaded.net.sf.cglib</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.objectweb.asm</pattern>
-                                    <shadedPattern>ru.custis.beanpath.shaded.org.objectweb.asm</shadedPattern>
+                                    <pattern>net.bytebuddy</pattern>
+                                    <shadedPattern>ru.custis.beanpath.shaded.net.bytebuddy</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>
@@ -85,23 +80,18 @@
 
     <dependencies>
 
-        <!-- TypeToken and type resolution mechanism  -->
+        <!-- TypeToken and type resolution mechanism -->
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>18.0</version>
         </dependency>
 
-        <!-- CGLIB with dependencies  -->
+        <!-- ByteBuddy -->
         <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib</artifactId>
-            <version>3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm-util</artifactId>
-            <version>4.0</version>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>0.7-rc6</version>
         </dependency>
 
         <!-- Syntactic sugar -->

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>ru.custis.beanpath</groupId>
     <artifactId>beanpath</artifactId>
-    <version>1.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>CUSTIS beanpath</name>

--- a/pom.xml
+++ b/pom.xml
@@ -58,18 +58,10 @@
                                     <include>org.ow2.asm:*</include>
                                 </includes>
                             </artifactSet>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/beans.xml</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
                             <relocations>
                                 <relocation>
-                                    <pattern>com.google.common</pattern>
-                                    <shadedPattern>ru.custis.beanpath.shaded.com.google.common</shadedPattern>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>ru.custis.beanpath.shaded.com.google</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>net.sf.cglib</pattern>
@@ -97,7 +89,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>15.0</version>
+            <version>18.0</version>
         </dependency>
 
         <!-- CGLIB with dependencies  -->

--- a/src/main/java/ru/custis/beanpath/BeanPath.java
+++ b/src/main/java/ru/custis/beanpath/BeanPath.java
@@ -30,7 +30,6 @@ import java.util.LinkedList;
  */
 @Immutable
 public class BeanPath<T> implements Iterable<BeanPath<?>>, Serializable {
-
     private static final long serialVersionUID = 42L;
 
     private final BeanPath<?> parent;
@@ -38,7 +37,6 @@ public class BeanPath<T> implements Iterable<BeanPath<?>>, Serializable {
     private final Class<T> type;
 
     private BeanPath(BeanPath<?> parent, String name, Class<T> type) {
-
         this.parent = parent;
         this.name = Assert.notNull(name, "name");
         this.type = Assert.notNull(type, "type");
@@ -209,7 +207,7 @@ public class BeanPath<T> implements Iterable<BeanPath<?>>, Serializable {
         return hc;
     }
 
-    // Instances of BeanPath is immutable,
+    // Instances of BeanPath are immutable,
     // thus we can lazy compute and cache derived properties.
     // Furthermore, we do not need synchronization:
     // its ok if two threads compute it twice concurrently.
@@ -233,7 +231,7 @@ public class BeanPath<T> implements Iterable<BeanPath<?>>, Serializable {
         return ts;
     }
 
-    // Instances of BeanPath is immutable,
+    // Instances of BeanPath are immutable,
     // thus we can lazy compute and cache derived properties.
     // Furthermore, we do not need synchronization:
     // its ok if two threads compute it twice concurrently.

--- a/src/main/java/ru/custis/beanpath/BeanPathMagic.java
+++ b/src/main/java/ru/custis/beanpath/BeanPathMagic.java
@@ -17,7 +17,7 @@
 package ru.custis.beanpath;
 
 import com.google.common.reflect.TypeToken;
-import net.sf.cglib.proxy.InvocationHandler;
+import ru.custis.beanpath.MockMaker.InvocationCallback;
 
 import javax.annotation.Nonnull;
 import java.lang.reflect.Method;
@@ -84,7 +84,7 @@ public class BeanPathMagic {
             return (T) mock;
         }
 
-        private static class MockInvocationHandler implements InvocationHandler {
+        private static class MockInvocationHandler implements InvocationCallback {
             // rawMockType can be inferred from mockType,
             // but TypeToken.getRawType() is relatively slow,
             // so avoid it in time critical invoke()

--- a/src/main/java/ru/custis/beanpath/BeanPathMagic.java
+++ b/src/main/java/ru/custis/beanpath/BeanPathMagic.java
@@ -62,7 +62,6 @@ public class BeanPathMagic {
     // --------------------------------------------------------- Implementation
 
     private static class Mocker {
-
         private static final Map<TypeToken, Object> cache = new ConcurrentHashMap<TypeToken, Object>();
         private static final Object mockCreationGuard = new Object();
 
@@ -86,7 +85,6 @@ public class BeanPathMagic {
         }
 
         private static class MockInvocationHandler implements InvocationHandler {
-
             // rawMockType can be inferred from mockType,
             // but TypeToken.getRawType() is relatively slow,
             // so avoid it in time critical invoke()
@@ -101,7 +99,6 @@ public class BeanPathMagic {
 
             @Override
             public Object invoke(Object target, Method method, Object[] args) throws Throwable {
-
                 CurrentPath.initIfNotAlready(rawMockType);
 
                 final Type genericReturnType = method.getGenericReturnType();
@@ -138,7 +135,6 @@ public class BeanPathMagic {
     }
 
     private static class CurrentPath {
-
         private static final ThreadLocal<BeanPath<?>> currentPathTL = new ThreadLocal<BeanPath<?>>();
 
         public static void initIfNotAlready(Class<?> clazz) {
@@ -161,11 +157,9 @@ public class BeanPathMagic {
     }
 
     private static class NameUtils {
-
         private static final String IS = "is", GET = "get";
 
         public static String stripGetIsPrefixIfAny(final String name) {
-
             assert (name != null);
 
             if (name.length() > GET.length() && name.startsWith(GET) && isUpperCase(name.charAt(GET.length()))) {
@@ -177,7 +171,6 @@ public class BeanPathMagic {
         }
 
         private static String stripAndDecapitalize(String name, String prefix) {
-
             final int nameLength = name.length();
             final int prefixLength = prefix.length();
             final int i = prefixLength + 1;

--- a/src/main/java/ru/custis/beanpath/BeanPathMagic.java
+++ b/src/main/java/ru/custis/beanpath/BeanPathMagic.java
@@ -23,6 +23,7 @@ import javax.annotation.Nonnull;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.lang.Character.isUpperCase;
@@ -62,7 +63,7 @@ public class BeanPathMagic {
 
     private static class Mocker {
 
-        private static final ConcurrentHashMap<TypeToken, Object> cache = new ConcurrentHashMap<TypeToken, Object>();
+        private static final Map<TypeToken, Object> cache = new ConcurrentHashMap<TypeToken, Object>();
         private static final Object mockCreationGuard = new Object();
 
         @SuppressWarnings("unchecked")

--- a/src/main/java/ru/custis/beanpath/BeanPathMagic.java
+++ b/src/main/java/ru/custis/beanpath/BeanPathMagic.java
@@ -49,7 +49,7 @@ public class BeanPathMagic {
     public static @Nonnull <T> BeanPath<T> $(T callChain) {
         final BeanPath<?> path = CurrentPath.evict();
         if (path == null) {
-            throw new BeanPathMagicException("No current path. Probably, call your chain consists a final method.");
+            throw new BeanPathMagicException("No current path. Probably your call chain contains a final method.");
         }
         return (BeanPath<T>) path;
     }

--- a/src/main/java/ru/custis/beanpath/BeanPathMagicException.java
+++ b/src/main/java/ru/custis/beanpath/BeanPathMagicException.java
@@ -19,7 +19,6 @@ package ru.custis.beanpath;
 import java.util.Formatter;
 
 public class BeanPathMagicException extends RuntimeException {
-
     /*package-local*/ BeanPathMagicException(String message) {
         super(message);
     }

--- a/src/main/java/ru/custis/beanpath/MockMaker.java
+++ b/src/main/java/ru/custis/beanpath/MockMaker.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /*package-local*/ class MockMaker {
     private MockMaker() {} // static use only
 
-    public static <T> T createMock(Class<T> type, InvocationHandler handler) throws Exception {
+    public static <T> T createMock(Class<T> type, InvocationHandler handler) throws InstantiationException {
         Assert.notNull(type, "type");
         Assert.notNull(handler, "handler");
 

--- a/src/main/java/ru/custis/beanpath/MockMaker.java
+++ b/src/main/java/ru/custis/beanpath/MockMaker.java
@@ -18,7 +18,12 @@ package ru.custis.beanpath;
 
 import net.sf.cglib.core.NamingPolicy;
 import net.sf.cglib.core.Predicate;
-import net.sf.cglib.proxy.*;
+import net.sf.cglib.proxy.Callback;
+import net.sf.cglib.proxy.CallbackFilter;
+import net.sf.cglib.proxy.Enhancer;
+import net.sf.cglib.proxy.Factory;
+import net.sf.cglib.proxy.InvocationHandler;
+import net.sf.cglib.proxy.NoOp;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -27,7 +32,12 @@ import java.util.concurrent.atomic.AtomicLong;
 /*package-local*/ class MockMaker {
     private MockMaker() {} // static use only
 
-    public static <T> T createMock(Class<T> type, InvocationHandler handler) throws InstantiationException {
+    public interface InvocationCallback extends InvocationHandler {
+        @Override
+        Object invoke(Object proxy, Method method, Object[] args) throws Throwable;
+    }
+
+    public static <T> T createMock(Class<T> type, InvocationCallback handler) throws InstantiationException {
         Assert.notNull(type, "type");
         Assert.notNull(handler, "handler");
 

--- a/src/main/java/ru/custis/beanpath/MockMaker.java
+++ b/src/main/java/ru/custis/beanpath/MockMaker.java
@@ -98,7 +98,7 @@ import java.util.concurrent.atomic.AtomicLong;
         }
     }
 
-    private static InvocationHandler defaultObjectMethodsHandler = new InvocationHandler() {
+    private static final InvocationHandler defaultObjectMethodsHandler = new InvocationHandler() {
         @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
             if (MethodsGuru.isEqualsMethod(method)) {
@@ -112,7 +112,7 @@ import java.util.concurrent.atomic.AtomicLong;
         }
     };
 
-    private static abstract class MethodsGuru {
+    private abstract static class MethodsGuru {
 
         public static boolean isEqualsHashCodeOrToStringMethod(Method method) {
             return isEqualsMethod(method) || isHashCodeMethod(method) || isToStringMethod(method);

--- a/src/main/java/ru/custis/beanpath/MockMaker.java
+++ b/src/main/java/ru/custis/beanpath/MockMaker.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.AtomicLong;
     private MockMaker() {} // static use only
 
     public static <T> T createMock(Class<T> type, InvocationHandler handler) throws Exception {
-
         Assert.notNull(type, "type");
         Assert.notNull(handler, "handler");
 
@@ -42,7 +41,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
     @SuppressWarnings("unchecked")
     private static <T> Class<T> generateClass(Class<T> clazzToMock) {
-
         final Enhancer enhancer = new Enhancer() {
             @Override protected void filterConstructors(Class sc, List constructors) {
                 // Don't filter; because default implementation filters out
@@ -83,7 +81,6 @@ import java.util.concurrent.atomic.AtomicLong;
     private static final Class[] CALLBACK_TYPES = new Class[]{InvocationHandler.class, NoOp.class, InvocationHandler.class};
 
     private static class MockCallbackFilter implements CallbackFilter {
-
         public static final MockCallbackFilter INSTANCE = new MockCallbackFilter();
 
         @Override
@@ -113,7 +110,6 @@ import java.util.concurrent.atomic.AtomicLong;
     };
 
     private abstract static class MethodsGuru {
-
         public static boolean isEqualsHashCodeOrToStringMethod(Method method) {
             return isEqualsMethod(method) || isHashCodeMethod(method) || isToStringMethod(method);
         }

--- a/src/main/java/ru/custis/beanpath/MockMaker.java
+++ b/src/main/java/ru/custis/beanpath/MockMaker.java
@@ -16,24 +16,30 @@
 
 package ru.custis.beanpath;
 
-import net.sf.cglib.core.NamingPolicy;
-import net.sf.cglib.core.Predicate;
-import net.sf.cglib.proxy.Callback;
-import net.sf.cglib.proxy.CallbackFilter;
-import net.sf.cglib.proxy.Enhancer;
-import net.sf.cglib.proxy.Factory;
-import net.sf.cglib.proxy.InvocationHandler;
-import net.sf.cglib.proxy.NoOp;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.NamingStrategy;
+import net.bytebuddy.implementation.bind.annotation.AllArguments;
+import net.bytebuddy.implementation.bind.annotation.Argument;
+import net.bytebuddy.implementation.bind.annotation.Origin;
+import net.bytebuddy.implementation.bind.annotation.RuntimeType;
+import net.bytebuddy.implementation.bind.annotation.This;
 
 import java.lang.reflect.Method;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static net.bytebuddy.dynamic.loading.ClassLoadingStrategy.Default.WRAPPER;
+import static net.bytebuddy.dynamic.scaffold.subclass.ConstructorStrategy.Default.NO_CONSTRUCTORS;
+import static net.bytebuddy.implementation.MethodDelegation.to;
+import static net.bytebuddy.matcher.ElementMatchers.isBridge;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 /*package-local*/ class MockMaker {
     private MockMaker() {} // static use only
 
-    public interface InvocationCallback extends InvocationHandler {
-        @Override
+    public interface InvocationCallback {
         Object invoke(Object proxy, Method method, Object[] args) throws Throwable;
     }
 
@@ -41,103 +47,79 @@ import java.util.concurrent.atomic.AtomicLong;
         Assert.notNull(type, "type");
         Assert.notNull(handler, "handler");
 
-        final Class mockClass = generateClass(type);
-        final Object mock = StolenUnsafe.getUnsafe().allocateInstance(mockClass);
-
-        ((Factory) mock).setCallbacks(new Callback[]{defaultObjectMethodsHandler, NoOp.INSTANCE, handler});
+        final Class<? extends T> mockClass = generateClass(type, handler);
+        final Object mock = instantiateClass(mockClass);
 
         return type.cast(mock);
     }
 
-    @SuppressWarnings("unchecked")
-    private static <T> Class<T> generateClass(Class<T> clazzToMock) {
-        final Enhancer enhancer = new Enhancer() {
-            @Override protected void filterConstructors(Class sc, List constructors) {
-                // Don't filter; because default implementation filters out
-                // private constructors, but we are not going to use constructors at all
-            }
-        };
+    private static final ByteBuddy buddy = new ByteBuddy().withNamingStrategy(new MockNamingStrategy());
 
-        enhancer.setUseCache(false);
-        enhancer.setUseFactory(true);
+    private static <T> Class<? extends T> generateClass(Class<T> clazzToMock, InvocationCallback handler) {
+        return
+                buddy
+                        .subclass(clazzToMock, NO_CONSTRUCTORS)
 
-        enhancer.setNamingPolicy(mockNamingPolicy);
+                        .method(not(isBridge()))
+                        .intercept(to(new InvocationCallbackAdapter(handler)))
 
-        // try to fix classloader issue
-        enhancer.setClassLoader(MockMaker.class.getClassLoader());
+                        .method(named("equals").and(returns(boolean.class)).and(takesArguments(Object.class)))
+                        .intercept(to(ObjectMethodsHandler.class))
 
-        if (clazzToMock.isInterface()) {
-            enhancer.setSuperclass(Object.class);
-            enhancer.setInterfaces(new Class[]{clazzToMock});
-        } else {
-            enhancer.setSuperclass(clazzToMock);
-        }
+                        .method(named("hashCode").and(returns(int.class)).and(takesArguments(0)))
+                        .intercept(to(ObjectMethodsHandler.class))
 
-        enhancer.setCallbackFilter(MockCallbackFilter.INSTANCE);
-        enhancer.setCallbackTypes(CALLBACK_TYPES);
+                        .method(named("toString").and(returns(String.class)).and(takesArguments(0)))
+                        .intercept(to(ObjectMethodsHandler.class))
 
-        return enhancer.createClass();
+                        .make()
+                        .load(MockMaker.class.getClassLoader(), WRAPPER)
+                        .getLoaded()
+        ;
     }
 
-    private static final AtomicLong counter = new AtomicLong(0);
+    private static <T> Object instantiateClass(Class<T> mockClass) throws InstantiationException {
+        return StolenUnsafe.getUnsafe().allocateInstance(mockClass);
+    }
 
-    private static final NamingPolicy mockNamingPolicy = new NamingPolicy() {
+    private static class MockNamingStrategy implements NamingStrategy {
+        private final AtomicLong counter = new AtomicLong(0);
+
         @Override
-        public String getClassName(String prefix, String source, Object key, Predicate names) {
+        public String name(UnnamedType unnamedType) {
+            String prefix = unnamedType.getSuperClass().getTypeName();
             return getClass().getPackage().getName() + ".BeanPathMagicMock_of_" + prefix + "_$" + counter.getAndIncrement();
         }
-    };
+    }
 
-    private static final Class[] CALLBACK_TYPES = new Class[]{InvocationHandler.class, NoOp.class, InvocationHandler.class};
+    @SuppressWarnings("unused")
+    public static class InvocationCallbackAdapter {
+        private final InvocationCallback callback;
 
-    private static class MockCallbackFilter implements CallbackFilter {
-        public static final MockCallbackFilter INSTANCE = new MockCallbackFilter();
+        public InvocationCallbackAdapter(InvocationCallback callback) {
+            this.callback = callback;
+        }
 
-        @Override
-        public int accept(Method method) {
-            if (MethodsGuru.isEqualsHashCodeOrToStringMethod(method)) {
-                return 0; // -> ObjectMethodsHandler.INSTANCE
-            } else if (method.isBridge()) {
-                return 1; // -> NoOp.INSTANCE
-            } else {
-                return 2; // -> InvocationHandler
-            }
+        @RuntimeType
+        public Object defaultHandler(@This Object proxy, @Origin Method method, @AllArguments Object[] args) throws Throwable {
+            return callback.invoke(proxy, method, args);
         }
     }
 
-    private static final InvocationHandler defaultObjectMethodsHandler = new InvocationHandler() {
-        @Override
-        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-            if (MethodsGuru.isEqualsMethod(method)) {
-                return (proxy == args[0]);
-            } else if (MethodsGuru.isHashCodeMethod(method)) {
-                return System.identityHashCode(proxy);
-            } else if (MethodsGuru.isToStringMethod(method)) {
-                return proxy.getClass().getName() + '@' + Integer.toHexString(System.identityHashCode(proxy));
-            }
-            throw new RuntimeException("Impossible occurred: Not a java.lang.Object method: " + method);
-        }
-    };
+    @SuppressWarnings("unused")
+    public static class ObjectMethodsHandler {
+        private ObjectMethodsHandler() {}
 
-    private abstract static class MethodsGuru {
-        public static boolean isEqualsHashCodeOrToStringMethod(Method method) {
-            return isEqualsMethod(method) || isHashCodeMethod(method) || isToStringMethod(method);
+        public static boolean equalsHandler(@This Object thiz, @Argument(0) Object that) {
+            return thiz == that;
         }
 
-        public static boolean isEqualsMethod(Method method) {
-            return method.getParameterTypes().length == 1
-                   && method.getName().equals("equals")
-                   && method.getParameterTypes()[0] == Object.class;
+        public static int hashCodeHandler(@This Object proxy) {
+            return System.identityHashCode(proxy);
         }
 
-        public static boolean isHashCodeMethod(Method method) {
-            return method.getParameterTypes().length == 0
-                   && method.getName().equals("hashCode");
-        }
-
-        public static boolean isToStringMethod(Method method) {
-            return method.getParameterTypes().length == 0
-                   && method.getName().equals("toString");
+        public static String toStringHandler(@This Object proxy) {
+            return proxy.getClass().getName() + '@' + Integer.toHexString(System.identityHashCode(proxy));
         }
     }
 }

--- a/src/main/java/ru/custis/beanpath/TypeLiteral.java
+++ b/src/main/java/ru/custis/beanpath/TypeLiteral.java
@@ -45,15 +45,16 @@ public abstract class TypeLiteral<T> {
 
     protected TypeLiteral() {
 
-        final Type genericSuperclass = this.getClass().getGenericSuperclass();
+        final Type genericSuperclass = getClass().getGenericSuperclass();
 
         if (genericSuperclass instanceof Class) {
             throw new IllegalArgumentException("Missing type argument");
         }
 
-        this.capturedType = ((ParameterizedType) genericSuperclass).getActualTypeArguments()[0];
+        capturedType = ((ParameterizedType) genericSuperclass).getActualTypeArguments()[0];
     }
 
+    @SuppressWarnings("unchecked")
     /*package-local*/ TypeToken<T> toTypeToken() {
         return (TypeToken<T>) TypeToken.of(capturedType);
     }

--- a/src/main/java/ru/custis/beanpath/TypeLiteral.java
+++ b/src/main/java/ru/custis/beanpath/TypeLiteral.java
@@ -40,11 +40,9 @@ import java.lang.reflect.Type;
  * embeds in type hierarchy and become available at runtime.
  */
 public abstract class TypeLiteral<T> {
-
     private final Type capturedType;
 
     protected TypeLiteral() {
-
         final Type genericSuperclass = getClass().getGenericSuperclass();
 
         if (genericSuperclass instanceof Class) {

--- a/src/test/java/ru/custis/beanpath/BeanPathBenchmark.java.off
+++ b/src/test/java/ru/custis/beanpath/BeanPathBenchmark.java.off
@@ -33,7 +33,6 @@ import static custis.toolbox.beanpath.BeanPathMagic.root;
 @Measurement(iterations = 10, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
 @Fork(1)
 public class BeanPathBenchmark {
-
     /*
      * This benchmark uses OpenJDK's jmh (http://openjdk.java.net/projects/code-tools/jmh/).
      *

--- a/src/test/java/ru/custis/beanpath/BeanPathMagicTest.java
+++ b/src/test/java/ru/custis/beanpath/BeanPathMagicTest.java
@@ -24,14 +24,12 @@ import static org.testng.Assert.*;
 import static ru.custis.beanpath.BeanPathMagic.*;
 
 public class BeanPathMagicTest {
-
     /*
      * Basic usage scenario
      */
 
     @Test
     public void basicUsage() {
-
         final Person person = root(Person.class);
 
         // String property
@@ -60,7 +58,6 @@ public class BeanPathMagicTest {
 
     @Test
     public void mockCaching() {
-
         // The Framework caches mock instances on its type basis for best performance
 
         assertSame(root(Person.class), root(Person.class));
@@ -71,7 +68,6 @@ public class BeanPathMagicTest {
     }
 
     public abstract static class Uninstantaible {
-
         private Uninstantaible() {
             throw new AssertionError();
         }
@@ -79,7 +75,6 @@ public class BeanPathMagicTest {
 
     @Test
     public void allocatingWithOutConstructorInvocation() {
-
         // The Framework allocates mock using sun.misc.Unsafe.allocateObject()
         // without constructor invocation
         root(Uninstantaible.class);
@@ -91,7 +86,6 @@ public class BeanPathMagicTest {
 
     @Test
     public void propertyNamingConcepts() {
-
         // Java Bean style properties converts appropriately
 
         final NamesBean names = root(NamesBean.class);
@@ -111,7 +105,6 @@ public class BeanPathMagicTest {
 
     @Test
     public void primitiveTypesWrapping() {
-
         // Primitive types promotes to their corresponding wrapper types
 
         final PrimitiveBean primitives = root(PrimitiveBean.class);
@@ -133,7 +126,6 @@ public class BeanPathMagicTest {
 
     @Test
     public void generics_actualTypeParameterResolution() {
-
         final Person person = root(Person.class);
 
         // The Framework is smart enough to resolve actual type parameter
@@ -142,7 +134,6 @@ public class BeanPathMagicTest {
 
     @Test
     public void generics_wildCardedTypes() {
-
         final Person person = root(Person.class);
 
         // Wildcard type parameter erases to its upper bound...
@@ -154,7 +145,6 @@ public class BeanPathMagicTest {
 
     @Test
     public void generics_TypeLiteralUsage() {
-
         // One can use TypeToken
         final Identified<String> identified = root(new TypeLiteral<Identified<String>>() {
         });
@@ -191,7 +181,6 @@ public class BeanPathMagicTest {
 
     @Test
     public void illegal_finalClass() {
-
         final Person person = root(Person.class);
 
         // Attempt to track property of final class fails with NullPointerException
@@ -211,7 +200,6 @@ public class BeanPathMagicTest {
     }
 
     public static class ParanoidPerson {
-
         private String getSecret() {
             return "The Secret";
         }
@@ -223,7 +211,6 @@ public class BeanPathMagicTest {
 
     @Test
     public void illegal_privateMethod() {
-
         final ParanoidPerson paranoidPerson = root(ParanoidPerson.class);
 
         // The Framework cannot intercept private method invocation
@@ -242,7 +229,6 @@ public class BeanPathMagicTest {
 
     @Test(expectedExceptions = BeanPathMagicException.class)
     public void illegal_finalMethod() {
-
         ParanoidPerson paranoidPerson = root(ParanoidPerson.class);
         assertEquals(paranoidPerson.getFinalSecret(), "The Final Secret");
 

--- a/src/test/java/ru/custis/beanpath/BeanPathMagicTest.java
+++ b/src/test/java/ru/custis/beanpath/BeanPathMagicTest.java
@@ -70,7 +70,7 @@ public class BeanPathMagicTest {
         }));
     }
 
-    public static abstract class Uninstantaible {
+    public abstract static class Uninstantaible {
 
         private Uninstantaible() {
             throw new AssertionError();

--- a/src/test/java/ru/custis/beanpath/BeanPathMagicTest.java
+++ b/src/test/java/ru/custis/beanpath/BeanPathMagicTest.java
@@ -184,7 +184,7 @@ public class BeanPathMagicTest {
      */
 
     @Test(expectedExceptions = BeanPathMagicException.class,
-            expectedExceptionsMessageRegExp = "No current path")
+            expectedExceptionsMessageRegExp = "No current path.*")
     public void illegal_noCurrentPath() {
         $(null);
     }
@@ -237,7 +237,7 @@ public class BeanPathMagicTest {
 
         // Such invocation just fall through to the real method
 
-        assertEquals(paranoidPerson.getSecret(), "The Secrete");
+        assertEquals(paranoidPerson.getSecret(), "The Secret");
     }
 
     @Test(expectedExceptions = BeanPathMagicException.class)

--- a/src/test/java/ru/custis/beanpath/BeanPathTest.java
+++ b/src/test/java/ru/custis/beanpath/BeanPathTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.*;
 
 public class BeanPathTest {
 
+    @SuppressWarnings("ConstantConditions")
     @Test
     public void basic() {
 

--- a/src/test/java/ru/custis/beanpath/BeanPathTest.java
+++ b/src/test/java/ru/custis/beanpath/BeanPathTest.java
@@ -27,11 +27,9 @@ import java.util.Iterator;
 import static org.testng.Assert.*;
 
 public class BeanPathTest {
-
     @SuppressWarnings("ConstantConditions")
     @Test
     public void basic() {
-
         final BeanPath<DatabaseMetaData> path =
                 BeanPath.root(DataSource.class).append("connection", Connection.class).append("metaData", DatabaseMetaData.class);
 
@@ -43,7 +41,6 @@ public class BeanPathTest {
 
     @Test
     public void pathInvariants() {
-
         final BeanPath<Connection> path = BeanPath.root(DataSource.class).append("connection", Connection.class);
 
         assertEquals(path.hasParent(), path.getParent() != null);
@@ -53,7 +50,6 @@ public class BeanPathTest {
 
     @Test
     public void rootInvariants() {
-
         final BeanPath<DataSource> root = BeanPath.root(DataSource.class);
 
         assertTrue(root.isRoot());
@@ -65,7 +61,6 @@ public class BeanPathTest {
 
     @Test
     public void dotDelimitedStringRepresentation() {
-
         final BeanPath<DatabaseMetaData> path =
                 BeanPath.root(DataSource.class).append("connection", Connection.class).append("metaData", DatabaseMetaData.class);
 
@@ -77,7 +72,6 @@ public class BeanPathTest {
 
     @Test
     public void iterator() {
-
         final BeanPath<DatabaseMetaData> path =
                 BeanPath.root(DataSource.class).append("connection", Connection.class).append("metaData", DatabaseMetaData.class);
 
@@ -93,7 +87,6 @@ public class BeanPathTest {
 
     @Test
     public void equalsAndHashCode() {
-
         final BeanPath<String> somePath = BeanPath.root(Object.class).append("foo", String.class);
         final BeanPath<String> samePath = BeanPath.root(Object.class).append("foo", String.class);
         final BeanPath<String> otherPath = BeanPath.root(Object.class).append("bar", String.class);
@@ -111,7 +104,6 @@ public class BeanPathTest {
 
     @Test
     public void toStringRepresentation() {
-
         final BeanPath<DatabaseMetaData> path =
                 BeanPath.root(DataSource.class).append("connection", Connection.class).append("metaData", DatabaseMetaData.class);
 

--- a/src/test/java/ru/custis/beanpath/MockMakerTest.java
+++ b/src/test/java/ru/custis/beanpath/MockMakerTest.java
@@ -64,10 +64,6 @@ public class MockMakerTest {
                 assertEquals(method.getDeclaringClass(), MyStringCallable.class);
                 assertEquals(method, expectedMethod);
 
-                StackTraceElement bridgeMethodStackTraceElement = new Exception().getStackTrace()[2];
-                assertEquals(bridgeMethodStackTraceElement.getClassName(), MyStringCallable.class.getName());
-                assertEquals(bridgeMethodStackTraceElement.getMethodName(), "call");
-
                 callbackInvoked.set(true);
 
                 return null;

--- a/src/test/java/ru/custis/beanpath/MockMakerTest.java
+++ b/src/test/java/ru/custis/beanpath/MockMakerTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.Callable;
 import static org.testng.Assert.*;
 
 public class MockMakerTest {
-
     private static final InvocationHandler errorThrowingHandler = new InvocationHandler() {
         @Override public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
             throw new AssertionError();
@@ -35,14 +34,12 @@ public class MockMakerTest {
 
     @Test
     public void creatingSeveralMocksOfSameType() throws Exception {
-
         MockMaker.createMock(Person.class, errorThrowingHandler);
         MockMaker.createMock(Person.class, errorThrowingHandler);
     }
 
     @Test
     public void namingPolicy() throws Exception {
-
         final Person mock = MockMaker.createMock(Person.class, errorThrowingHandler);
 
         final String mockClassName = mock.getClass().getName();
@@ -57,7 +54,6 @@ public class MockMakerTest {
 
     @Test
     public void bridgeMethodDelegation() throws Exception {
-
         final boolean[] wasInvoked = new boolean[]{false};
 
         final MyStringCallable mock = MockMaker.createMock(MyStringCallable.class, new InvocationHandler() {
@@ -83,7 +79,6 @@ public class MockMakerTest {
     @SuppressWarnings({"ObjectEqualsNull", "EqualsWithItself"})
     @Test
     public void equalsMethodImplementation() throws Exception {
-
         final Person mock = MockMaker.createMock(Person.class, errorThrowingHandler);
 
         assertTrue(mock.equals(mock));
@@ -93,7 +88,6 @@ public class MockMakerTest {
 
     @Test
     public void hashCodeMethodImplementation() throws Exception {
-
         final Person mock = MockMaker.createMock(Person.class, errorThrowingHandler);
 
         assertEquals(mock.hashCode(), mock.hashCode());
@@ -101,7 +95,6 @@ public class MockMakerTest {
 
     @Test
     public void toStringMethodImplementation() throws Exception {
-
         final Person mock = MockMaker.createMock(Person.class, errorThrowingHandler);
 
         assertTrue(mock.toString().startsWith("ru.custis.beanpath.BeanPathMagicMock_of_" + Person.class.getName()));

--- a/src/test/java/ru/custis/beanpath/MockMakerTest.java
+++ b/src/test/java/ru/custis/beanpath/MockMakerTest.java
@@ -16,8 +16,8 @@
 
 package ru.custis.beanpath;
 
-import net.sf.cglib.proxy.InvocationHandler;
 import org.testng.annotations.Test;
+import ru.custis.beanpath.MockMaker.InvocationCallback;
 import ru.custis.beanpath.beans.Person;
 
 import java.lang.reflect.Method;
@@ -26,7 +26,7 @@ import java.util.concurrent.Callable;
 import static org.testng.Assert.*;
 
 public class MockMakerTest {
-    private static final InvocationHandler errorThrowingHandler = new InvocationHandler() {
+    private static final InvocationCallback errorThrowingHandler = new InvocationCallback() {
         @Override public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
             throw new AssertionError();
         }
@@ -56,7 +56,7 @@ public class MockMakerTest {
     public void bridgeMethodDelegation() throws Exception {
         final boolean[] wasInvoked = new boolean[]{false};
 
-        final MyStringCallable mock = MockMaker.createMock(MyStringCallable.class, new InvocationHandler() {
+        final MyStringCallable mock = MockMaker.createMock(MyStringCallable.class, new InvocationCallback() {
             @Override public Object invoke(Object proxy, Method method, Object[] args) {
                 assertEquals(method.getDeclaringClass(), MyStringCallable.class);
 

--- a/src/test/java/ru/custis/beanpath/MockMakerTest.java
+++ b/src/test/java/ru/custis/beanpath/MockMakerTest.java
@@ -47,7 +47,7 @@ public class MockMakerTest {
     }
 
     public static class MyStringCallable implements Callable<String> {
-        @Override public String call() throws Exception {
+        @Override public String call() {
             return null;
         }
     }
@@ -57,8 +57,7 @@ public class MockMakerTest {
         final boolean[] wasInvoked = new boolean[]{false};
 
         final MyStringCallable mock = MockMaker.createMock(MyStringCallable.class, new InvocationHandler() {
-            @Override public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-
+            @Override public Object invoke(Object proxy, Method method, Object[] args) {
                 assertEquals(method.getDeclaringClass(), MyStringCallable.class);
 
                 final StackTraceElement bridgeMethodStackTraceElement = new Exception().getStackTrace()[2];

--- a/src/test/java/ru/custis/beanpath/MockMakerTest.java
+++ b/src/test/java/ru/custis/beanpath/MockMakerTest.java
@@ -80,6 +80,7 @@ public class MockMakerTest {
         assertTrue(wasInvoked[0]);
     }
 
+    @SuppressWarnings({"ObjectEqualsNull", "EqualsWithItself"})
     @Test
     public void equalsMethodImplementation() throws Exception {
 

--- a/src/test/java/ru/custis/beanpath/MockMakerTest.java
+++ b/src/test/java/ru/custis/beanpath/MockMakerTest.java
@@ -96,7 +96,7 @@ public class MockMakerTest {
     public void toStringMethodImplementation() throws Exception {
         final Person mock = MockMaker.createMock(Person.class, errorThrowingHandler);
 
-        assertTrue(mock.toString().startsWith("ru.custis.beanpath.BeanPathMagicMock_of_" + Person.class.getName()));
+        assertTrue(mock.toString().startsWith(mock.getClass().getName()));
         assertTrue(mock.toString().contains("@"));
     }
 }

--- a/src/test/java/ru/custis/beanpath/beans/Document.java
+++ b/src/test/java/ru/custis/beanpath/beans/Document.java
@@ -17,7 +17,6 @@
 package ru.custis.beanpath.beans;
 
 public class Document {
-
     public String getNumber() { return "123"; }
 
     public String getIssuedBy() { return "Issuer"; }

--- a/src/test/java/ru/custis/beanpath/beans/Gender.java
+++ b/src/test/java/ru/custis/beanpath/beans/Gender.java
@@ -16,6 +16,7 @@
 
 package ru.custis.beanpath.beans;
 
+@SuppressWarnings("unused")
 public enum Gender {
 
     MALE, FEMALE

--- a/src/test/java/ru/custis/beanpath/beans/Gender.java
+++ b/src/test/java/ru/custis/beanpath/beans/Gender.java
@@ -18,6 +18,5 @@ package ru.custis.beanpath.beans;
 
 @SuppressWarnings("unused")
 public enum Gender {
-
     MALE, FEMALE
 }

--- a/src/test/java/ru/custis/beanpath/beans/Identified.java
+++ b/src/test/java/ru/custis/beanpath/beans/Identified.java
@@ -17,6 +17,5 @@
 package ru.custis.beanpath.beans;
 
 public abstract class Identified<ID> {
-
     public ID getId() { return null; }
 }

--- a/src/test/java/ru/custis/beanpath/beans/NamesBean.java
+++ b/src/test/java/ru/custis/beanpath/beans/NamesBean.java
@@ -17,7 +17,6 @@
 package ru.custis.beanpath.beans;
 
 public class NamesBean {
-
     public Object getProperty() { return null; }
 
     public Object isProperty() { return null; }

--- a/src/test/java/ru/custis/beanpath/beans/Person.java
+++ b/src/test/java/ru/custis/beanpath/beans/Person.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 @SuppressWarnings("UnusedParameters")
 public class Person extends Identified<Long> {
-
     public String getName() { return "John Smith"; }
 
     public int getAge() { return 27; }

--- a/src/test/java/ru/custis/beanpath/beans/Person.java
+++ b/src/test/java/ru/custis/beanpath/beans/Person.java
@@ -19,6 +19,7 @@ package ru.custis.beanpath.beans;
 import java.util.Iterator;
 import java.util.List;
 
+@SuppressWarnings("UnusedParameters")
 public class Person extends Identified<Long> {
 
     public String getName() { return "John Smith"; }

--- a/src/test/java/ru/custis/beanpath/beans/PrimitiveBean.java
+++ b/src/test/java/ru/custis/beanpath/beans/PrimitiveBean.java
@@ -17,7 +17,6 @@
 package ru.custis.beanpath.beans;
 
 public class PrimitiveBean {
-
     public boolean getBoolean() { return false; }
 
     public char getChar() { return 0; }


### PR DESCRIPTION
Preliminary cleanup actions (fixed broken unit test, some code style cleanup and minor fixes, Guava and TestNG versions upgraded) + migration from Cglib to ByteBuddy.
The reason for the migration: Cglib is not actively maintained and have troubles with Java 8.